### PR TITLE
refactor: drop helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,10 +364,10 @@ Setting `debug` level will print out all logs, including `info`, `warning`, and 
 
 ```php
 use Featurevisor\Featurevisor;
-use function Featurevisor\createLogger;
+use Featurevisor\Logger;
 
 $f = Featurevisor::createInstance([
-  "logger" => createLogger([
+  "logger" => Logger::create([
     "level" => "debug",
   ]),
 ]);
@@ -393,10 +393,10 @@ You can also pass your own log handler, if you do not wish to print the logs to 
 
 ```php
 use Featurevisor\Featurevisor;
-use function Featurevisor\createLogger;
+use Featurevisor\Logger;
 
 $f = Featurevisor::createInstance([
-  "logger" => createLogger([
+  "logger" => Logger::create([
     "level" => "info",
     "handler" => function ($level, $message, $details) {
       // do something with the log

--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ The SDK can be initialized by passing [datafile](https://featurevisor.com/docs/b
 ```php
 <?php
 
-use function Featurevisor\createInstance;
+use Featurevisor\Featurevisor;
 
 $datafileUrl = "https://cdn.yoursite.com/datafile.json";
 
 $datafileContent = file_get_contents($datafileUrl);
 $datafileContent = json_decode($datafileContent, true);
 
-$f = createInstance([
+$f = Featurevisor::createInstance([
   "datafile" => $datafileContent
 ]);
 ```
@@ -107,9 +107,9 @@ Context can be passed to SDK instance in various different ways, depending on yo
 You can set context at the time of initialization:
 
 ```php
-use function Featurevisor\createInstance;
+use Featurevisor\Featurevisor;
 
-$f = createInstance([
+$f = Featurevisor::createInstance([
   "context" => [
     "deviceId" => "123",
     "country" => "nl",
@@ -278,9 +278,9 @@ For the lifecycle of the SDK instance in your application, you can set some feat
 ### Initialize with sticky
 
 ```php
-use function Featurevisor\createInstance;
+use Featurevisor\Featurevisor;
 
-$f = createInstance([
+$f = Featurevisor::createInstance([
   "sticky" => [
     "myFeatureKey" => [
       "enabled" => true,
@@ -363,10 +363,10 @@ If you choose `debug` level to make the logs more verbose, you can set it at the
 Setting `debug` level will print out all logs, including `info`, `warning`, and `error` levels.
 
 ```php
-use function Featurevisor\createInstance;
+use Featurevisor\Featurevisor;
 use function Featurevisor\createLogger;
 
-$f = createInstance([
+$f = Featurevisor::createInstance([
   "logger" => createLogger([
     "level" => "debug",
   ]),
@@ -376,7 +376,7 @@ $f = createInstance([
 Alternatively, you can also set `logLevel` directly:
 
 ```php
-$f = createInstance([
+$f = Featurevisor::createInstance([
   "logLevel" => "debug",
 ]);
 ```
@@ -392,10 +392,10 @@ $f->setLogLevel("debug");
 You can also pass your own log handler, if you do not wish to print the logs to the console:
 
 ```php
-use function Featurevisor\createInstance;
+use Featurevisor\Featurevisor;
 use function Featurevisor\createLogger;
 
-$f = createInstance([
+$f = Featurevisor::createInstance([
   "logger" => createLogger([
     "level" => "info",
     "handler" => function ($level, $message, $details) {
@@ -566,9 +566,9 @@ $myCustomHook = [
 You can register hooks at the time of SDK initialization:
 
 ```php
-use function Featurevisor\createInstance;
+use Featurevisor\Featurevisor;
 
-$f = createInstance([
+$f = Featurevisor::createInstance([
   'hooks' => [
     $myCustomHook
   ],

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ $f->setDatafile($datafileContent);
 
 ### Updating datafile
 
-You can set the datafile as many times as you want in your application, which will result in emitting a [`datafile_set`](#datafile-set) event that you can listen and react to accordingly.
+You can set the datafile as many times as you want in your application, which will result in emitting a [`datafile_set`](#datafile_set) event that you can listen and react to accordingly.
 
 The triggers for setting the datafile again can be:
 

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,7 @@
   "autoload": {
     "psr-4": {
       "Featurevisor\\": "src/"
-    },
-    "files": [
-      "src/functions.php"
-    ]
+    }
   },
   "autoload-dev": {
     "psr-4": {

--- a/featurevisor
+++ b/featurevisor
@@ -255,7 +255,7 @@ function testSegment(array $assertion, array $segment, string $level): array {
         'segments' => []
     ];
 
-    $datafileReader = new DatafileReader([
+    $datafileReader = DatafileReader::createFromOptions([
         'datafile' => $datafile,
         'logger' => createLogger([
             'level' => $level,

--- a/featurevisor
+++ b/featurevisor
@@ -5,8 +5,8 @@ require __DIR__ . '/vendor/autoload.php';
 
 use Featurevisor\DatafileReader;
 use Featurevisor\Featurevisor;
+use Featurevisor\Logger;
 use Psr\Log\LogLevel;
-use function Featurevisor\createLogger;
 
 /**
  * CLI Options
@@ -257,7 +257,7 @@ function testSegment(array $assertion, array $segment, string $level): array {
 
     $datafileReader = DatafileReader::createFromOptions([
         'datafile' => $datafile,
-        'logger' => createLogger([
+        'logger' => Logger::create([
             'level' => $level,
         ]),
     ]);
@@ -306,7 +306,7 @@ function test(array $cliOptions) {
         $datafile = $datafilesByEnvironment[$environment];
         $sdkInstancesByEnvironment[$environment] = Featurevisor::createInstance([
             'datafile' => $datafile,
-            'logger' => createLogger([
+            'logger' => Logger::create([
               'level' => $level,
             ]),
             'hooks' => [
@@ -345,7 +345,7 @@ function test(array $cliOptions) {
                     $datafile = $datafilesByEnvironment[$environment];
                     $f = Featurevisor::createInstance([
                         'datafile' => $datafile,
-                        'logger' => createLogger([
+                        'logger' => Logger::create([
                           'level' => $level,
                         ]),
                         'hooks' => [
@@ -422,7 +422,7 @@ function benchmark(array $cliOptions) {
 
     $f = Featurevisor::createInstance([
         'datafile' => $datafilesByEnvironment[$cliOptions['environment']],
-        'logger' => createLogger([
+        'logger' => Logger::create([
           'level' => $level,
         ]),
     ]);
@@ -483,7 +483,7 @@ function assessDistribution(array $cliOptions) {
 
     $f = Featurevisor::createInstance([
         'datafile' => $datafilesByEnvironment[$cliOptions['environment']],
-        'logger' => createLogger([
+        'logger' => Logger::create([
           'level' => $level,
         ]),
     ]);

--- a/featurevisor
+++ b/featurevisor
@@ -4,8 +4,8 @@
 require __DIR__ . '/vendor/autoload.php';
 
 use Featurevisor\DatafileReader;
+use Featurevisor\Featurevisor;
 use Psr\Log\LogLevel;
-use function Featurevisor\createInstance;
 use function Featurevisor\createLogger;
 
 /**
@@ -304,7 +304,7 @@ function test(array $cliOptions) {
     $sdkInstancesByEnvironment = [];
     foreach ($environments as $environment) {
         $datafile = $datafilesByEnvironment[$environment];
-        $sdkInstancesByEnvironment[$environment] = createInstance([
+        $sdkInstancesByEnvironment[$environment] = Featurevisor::createInstance([
             'datafile' => $datafile,
             'logger' => createLogger([
               'level' => $level,
@@ -343,7 +343,7 @@ function test(array $cliOptions) {
                 // If "at" parameter is provided, create a new SDK instance with the specific hook
                 if (isset($assertion["at"])) {
                     $datafile = $datafilesByEnvironment[$environment];
-                    $f = createInstance([
+                    $f = Featurevisor::createInstance([
                         'datafile' => $datafile,
                         'logger' => createLogger([
                           'level' => $level,
@@ -420,7 +420,7 @@ function benchmark(array $cliOptions) {
     $level = getLoggerLevel($cliOptions);
     $datafilesByEnvironment = buildDatafiles($featurevisorProjectPath, [$cliOptions['environment']]);
 
-    $f = createInstance([
+    $f = Featurevisor::createInstance([
         'datafile' => $datafilesByEnvironment[$cliOptions['environment']],
         'logger' => createLogger([
           'level' => $level,
@@ -481,7 +481,7 @@ function assessDistribution(array $cliOptions) {
     $datafilesByEnvironment = buildDatafiles($featurevisorProjectPath, [$cliOptions['environment']]);
     $level = getLoggerLevel($cliOptions);
 
-    $f = createInstance([
+    $f = Featurevisor::createInstance([
         'datafile' => $datafilesByEnvironment[$cliOptions['environment']],
         'logger' => createLogger([
           'level' => $level,

--- a/src/DatafileReader.php
+++ b/src/DatafileReader.php
@@ -2,6 +2,9 @@
 
 namespace Featurevisor;
 
+use Exception;
+use InvalidArgumentException;
+use JsonException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -29,6 +32,10 @@ class DatafileReader
         ]);
     }
 
+    /**
+     * @param string|array<string, mixed> $datafile
+     * @throws JsonException
+     */
     public static function createFromMixed($datafile, LoggerInterface $logger): self
     {
         return is_string($datafile)
@@ -40,7 +47,7 @@ class DatafileReader
     }
 
     /**
-     * @throws \JsonException
+     * @throws JsonException
      */
     public static function createFromJson(string $json, LoggerInterface $logger): self
     {
@@ -55,7 +62,7 @@ class DatafileReader
     public static function createFromOptions(array $data): self
     {
         if (array_key_exists('datafile', $data) === false ) {
-            throw new \InvalidArgumentException('Missing datafile key in data array');
+            throw new InvalidArgumentException('Missing datafile key in data array');
         }
 
         return new self(
@@ -203,7 +210,7 @@ class DatafileReader
             if (isset($conditions['attribute'])) {
                 try {
                     return Conditions::conditionIsMatched($conditions, $context, $getRegex);
-                } catch (\Exception $e) {
+                } catch (Exception $e) {
                     $this->logger->warning($e->getMessage(), [
                         'exception' => $e,
                         'condition' => $conditions,

--- a/src/Featurevisor.php
+++ b/src/Featurevisor.php
@@ -16,7 +16,7 @@ class Featurevisor
 
     /**
      * @param array{
-     *     datafile?: string|array,
+     *     datafile?: string|array<string, mixed>,
      *     logger?: LoggerInterface,
      *     context?: array<string, mixed>,
      *     sticky?: array<string, mixed>,
@@ -65,6 +65,9 @@ class Featurevisor
         $this->logger->info('Featurevisor SDK initialized');
     }
 
+    /**
+     * @param string|array<string, mixed> $datafile
+     */
     public function setDatafile($datafile): void
     {
         try {
@@ -77,10 +80,13 @@ class Featurevisor
             $this->logger->info('datafile set', $details);
             $this->emitter->trigger('datafile_set', $details);
         } catch (\Exception $e) {
-            $this->logger->error('could not parse datafile', ['error' => $e->getMessage(), 'exception' => $e]);;
+            $this->logger->error('could not parse datafile', ['error' => $e->getMessage(), 'exception' => $e]);
         }
     }
 
+    /**
+     * @param array<string, mixed> $sticky
+     */
     public function setSticky(array $sticky, bool $replace = false): void
     {
         $previousStickyFeatures = $this->sticky ?? [];
@@ -122,6 +128,9 @@ class Featurevisor
         $this->emitter->clearAll();
     }
 
+    /**
+     * @param array<string, mixed> $context
+     */
     public function setContext(array $context, bool $replace = false): void
     {
         if ($replace) {
@@ -141,11 +150,22 @@ class Featurevisor
         ]);
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @return array<string, mixed>
+     */
     public function getContext(array $context = []): array
     {
         return !empty($context) ? array_merge($this->context, $context) : $this->context;
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     sticky?: array<string, mixed>
+     * } $options
+     * @return Child
+     */
     public function spawn(array $context = [], array $options = []): Child
     {
         return new Child([
@@ -155,6 +175,16 @@ class Featurevisor
         ]);
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     * @return array
+     */
     private function getEvaluationDependencies(array $context, array $options = []): array
     {
         $sticky = $this->sticky;
@@ -177,6 +207,24 @@ class Featurevisor
         ]);
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     * @return array{
+     *     type: string,
+     *     featureKey: string,
+     *     reason: string,
+     *     bucketKey: string,
+     *     bucketValue: string,
+     *     enabled: bool,
+     *     error?: string,
+     * }
+     */
     public function evaluateFlag(string $featureKey, array $context = [], array $options = []): array
     {
         $deps = $this->getEvaluationDependencies($context, $options);
@@ -187,6 +235,15 @@ class Featurevisor
         ]));
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     */
     public function isEnabled(string $featureKey, array $context = [], array $options = []): bool
     {
         $evaluation = $this->evaluateFlag($featureKey, $context, $options);
@@ -194,6 +251,24 @@ class Featurevisor
         return $evaluation['enabled'] ?? false;
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     * @return array{
+     *     type: string,
+     *     featureKey: string,
+     *     reason: string,
+     *     bucketKey: string,
+     *     bucketValue: string,
+     *     enabled: bool,
+     *     error?: string,
+     * }
+     */
     public function evaluateVariation(string $featureKey, array $context = [], array $options = []): array
     {
         $deps = $this->getEvaluationDependencies($context, $options);
@@ -204,6 +279,16 @@ class Featurevisor
         ]));
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     * @return mixed|null
+     */
     public function getVariation(string $featureKey, array $context = [], array $options = [])
     {
         try {
@@ -229,6 +314,24 @@ class Featurevisor
         }
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     * @return array{
+     *     type: string,
+     *     featureKey: string,
+     *     reason: string,
+     *     bucketKey: string,
+     *     bucketValue: string,
+     *     enabled: bool,
+     *     error?: string,
+     * }
+     */
     public function evaluateVariable(string $featureKey, string $variableKey, array $context = [], array $options = []): array
     {
         $deps = $this->getEvaluationDependencies($context, $options);
@@ -240,6 +343,16 @@ class Featurevisor
         ]));
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     * @return mixed|null
+     */
     public function getVariable(string $featureKey, string $variableKey, array $context = [], array $options = [])
     {
         try {
@@ -271,6 +384,15 @@ class Featurevisor
         }
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     */
     public function getVariableBoolean(string $featureKey, string $variableKey, array $context = [], array $options = []): ?bool
     {
         $value = $this->getVariable($featureKey, $variableKey, $context, $options);
@@ -282,6 +404,15 @@ class Featurevisor
         return (bool) $value;
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     */
     public function getVariableString(string $featureKey, string $variableKey, array $context = [], array $options = []): ?string
     {
         $value = $this->getVariable($featureKey, $variableKey, $context, $options);
@@ -293,6 +424,15 @@ class Featurevisor
         return (string) $value;
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     */
     public function getVariableInteger(string $featureKey, string $variableKey, array $context = [], array $options = []): ?int
     {
         $value = $this->getVariable($featureKey, $variableKey, $context, $options);
@@ -304,6 +444,15 @@ class Featurevisor
         return (int) $value;
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     */
     public function getVariableDouble(string $featureKey, string $variableKey, array $context = [], array $options = []): ?float
     {
         $value = $this->getVariable($featureKey, $variableKey, $context, $options);
@@ -315,6 +464,15 @@ class Featurevisor
         return (float) $value;
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     */
     public function getVariableArray(string $featureKey, string $variableKey, array $context = [], array $options = []): ?array
     {
         $value = $this->getVariable($featureKey, $variableKey, $context, $options);
@@ -326,6 +484,15 @@ class Featurevisor
         return is_array($value) ? $value : [$value];
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     */
     public function getVariableObject(string $featureKey, string $variableKey, array $context = [], array $options = [])
     {
         $value = $this->getVariable($featureKey, $variableKey, $context, $options);
@@ -337,6 +504,16 @@ class Featurevisor
         return is_array($value) ? $value : null;
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     * @return array<mixed>|mixed|null
+     */
     public function getVariableJSON(string $featureKey, string $variableKey, array $context = [], array $options = [])
     {
         $value = $this->getVariable($featureKey, $variableKey, $context, $options);
@@ -353,6 +530,17 @@ class Featurevisor
         return $value;
     }
 
+    /**
+     * @param array<string, mixed> $context
+     * @param array<string> $featureKeys
+     * @param array{
+     *     defaultVariationValue?: mixed,
+     *     defaultVariableValue?: mixed,
+     *     flagEvaluation?: array<string, mixed>,
+     *     sticky?: array<string, mixed>
+     * } $options
+     * @return array<string, mixed>
+     */
     public function getAllEvaluations(array $context = [], array $featureKeys = [], array $options = []): array
     {
         $deps = $this->getEvaluationDependencies($context, $options);

--- a/src/Featurevisor.php
+++ b/src/Featurevisor.php
@@ -2,6 +2,7 @@
 
 namespace Featurevisor;
 
+use Closure;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -265,6 +266,7 @@ class Featurevisor
      *     reason: string,
      *     bucketKey: string,
      *     bucketValue: string,
+     *     variation: array<string, mixed>,
      *     enabled: bool,
      *     error?: string,
      * }

--- a/src/HooksManager.php
+++ b/src/HooksManager.php
@@ -2,24 +2,63 @@
 
 namespace Featurevisor;
 
+use Closure;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class HooksManager
 {
     private array $hooks = [];
     private LoggerInterface $logger;
 
-    public function __construct(array $options)
+    /**
+     * @param array{
+     *     hooks?: array<array{
+     *         name: string,
+     *         before: Closure,
+     *         after: Closure,
+     *         bucketKey: Closure,
+     *         bucketValue: Closure
+     *     }>,
+     *     logger?: LoggerInterface,
+     * } $options
+     * @return self
+     */
+    public static function createFromOptions(array $options): self
     {
-        $this->logger = $options['logger'];
+        return new self(
+            $options['hooks'] ?? [],
+            $options['logger'] ?? new NullLogger()
+        );
+    }
 
-        if (isset($options['hooks'])) {
-            foreach ($options['hooks'] as $hook) {
-                $this->add($hook);
-            }
+    /**
+     * @param array<array{
+     *     name: string,
+     *     before: Closure,
+     *     after: Closure,
+     *     bucketKey: Closure,
+     *     bucketValue: Closure
+     * }> $hooks
+     */
+    public function __construct(array $hooks, LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+        foreach ($hooks as $hook) {
+            $this->add($hook);
         }
     }
 
+    /**
+     * @param array{
+     *      name: string,
+     *      before: Closure,
+     *      after: Closure,
+     *      bucketKey: Closure,
+     *      bucketValue: Closure
+     *  } $hook
+     * @return callable|null
+     */
     public function add(array $hook): ?callable
     {
         foreach ($this->hooks as $existingHook) {

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -36,10 +36,18 @@ class Logger implements LoggerInterface
      *     handler?: Closure,
      * } $options
      */
-    public function __construct(array $options = [])
+    public static function create(array $options = []): self
     {
-        $this->level = $options['level'] ?? self::DEFAULT_LEVEL;
-        $this->handler = $options['handler'] ?? static fn ($level, $message, array $context) => self::defaultLogHandler($level, $message, $context);
+        return new self(
+            $options['level'] ?? self::DEFAULT_LEVEL,
+            $options['handler'] ?? null
+        );
+    }
+
+    public function __construct(string $level = self::DEFAULT_LEVEL, Closure $handler = null)
+    {
+        $this->handler = $handler ?? static fn ($level, $message, array $context) => self::defaultLogHandler($level, $message, $context);
+        $this->level = $level;
     }
 
     public function setLevel(string $level): void
@@ -62,7 +70,7 @@ class Logger implements LoggerInterface
         ($this->handler)($level, self::MSG_PREFIX.' '.$message, $context);
     }
 
-    public static function defaultLogHandler($level, $message, ?array $details = null): void
+    private static function defaultLogHandler($level, $message, ?array $details = null): void
     {
         if (STDOUT === false) {
             return;

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace Featurevisor;
-
-function createLogger(array $options = []): Logger
-{
-    return new Logger($options);
-}

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,11 +2,6 @@
 
 namespace Featurevisor;
 
-function createInstance(array $options = []): Featurevisor
-{
-    return Featurevisor::createInstance($options);
-}
-
 function createLogger(array $options = []): Logger
 {
     return new Logger($options);

--- a/src/functions.php
+++ b/src/functions.php
@@ -2,9 +2,9 @@
 
 namespace Featurevisor;
 
-function createInstance(array $options = []): Instance
+function createInstance(array $options = []): Featurevisor
 {
-    return new Instance($options);
+    return Featurevisor::createInstance($options);
 }
 
 function createLogger(array $options = []): Logger

--- a/tests/BucketerTest.php
+++ b/tests/BucketerTest.php
@@ -2,11 +2,10 @@
 
 namespace Featurevisor\Tests;
 
+use Featurevisor\Logger;
 use PHPUnit\Framework\TestCase;
-
 use Featurevisor\Bucketer;
 use Psr\Log\LogLevel;
-use function Featurevisor\createLogger;
 
 class BucketerTest extends TestCase {
 
@@ -43,7 +42,7 @@ class BucketerTest extends TestCase {
         $featureKey = 'test-feature';
         $bucketBy = 'userId';
         $context = ['userId' => '123', 'browser' => 'chrome'];
-        $logger = createLogger(['level' => LogLevel::WARNING]);
+        $logger = Logger::create(['level' => LogLevel::WARNING]);
         $bucketKey = Bucketer::getBucketKey([
             'featureKey' => $featureKey,
             'bucketBy' => $bucketBy,
@@ -57,7 +56,7 @@ class BucketerTest extends TestCase {
         $featureKey = 'test-feature';
         $bucketBy = 'userId';
         $context = ['browser' => 'chrome'];
-        $logger = createLogger(['level' => LogLevel::WARNING]);
+        $logger = Logger::create(['level' => LogLevel::WARNING]);
         $bucketKey = Bucketer::getBucketKey([
             'featureKey' => $featureKey,
             'bucketBy' => $bucketBy,
@@ -71,7 +70,7 @@ class BucketerTest extends TestCase {
         $featureKey = 'test-feature';
         $bucketBy = ['organizationId', 'userId'];
         $context = ['organizationId' => '123', 'userId' => '234', 'browser' => 'chrome'];
-        $logger = createLogger(['level' => LogLevel::WARNING]);
+        $logger = Logger::create(['level' => LogLevel::WARNING]);
         $bucketKey = Bucketer::getBucketKey([
             'featureKey' => $featureKey,
             'bucketBy' => $bucketBy,
@@ -85,7 +84,7 @@ class BucketerTest extends TestCase {
         $featureKey = 'test-feature';
         $bucketBy = ['organizationId', 'userId'];
         $context = ['organizationId' => '123', 'browser' => 'chrome'];
-        $logger = createLogger(['level' => LogLevel::WARNING]);
+        $logger = Logger::create(['level' => LogLevel::WARNING]);
         $bucketKey = Bucketer::getBucketKey([
             'featureKey' => $featureKey,
             'bucketBy' => $bucketBy,
@@ -103,7 +102,7 @@ class BucketerTest extends TestCase {
             'user' => ['id' => '234'],
             'browser' => 'chrome',
         ];
-        $logger = createLogger(['level' => LogLevel::WARNING]);
+        $logger = Logger::create(['level' => LogLevel::WARNING]);
         $bucketKey = Bucketer::getBucketKey([
             'featureKey' => $featureKey,
             'bucketBy' => $bucketBy,
@@ -121,7 +120,7 @@ class BucketerTest extends TestCase {
         $featureKey = 'test-feature';
         $bucketBy = ['or' => ['userId', 'deviceId']];
         $context = ['deviceId' => 'deviceIdHere', 'userId' => '234', 'browser' => 'chrome'];
-        $logger = createLogger(['level' => LogLevel::WARNING]);
+        $logger = Logger::create(['level' => LogLevel::WARNING]);
         $bucketKey = Bucketer::getBucketKey([
             'featureKey' => $featureKey,
             'bucketBy' => $bucketBy,
@@ -135,7 +134,7 @@ class BucketerTest extends TestCase {
         $featureKey = 'test-feature';
         $bucketBy = ['or' => ['userId', 'deviceId']];
         $context = ['deviceId' => 'deviceIdHere', 'browser' => 'chrome'];
-        $logger = createLogger(['level' => LogLevel::WARNING]);
+        $logger = Logger::create(['level' => LogLevel::WARNING]);
         $bucketKey = Bucketer::getBucketKey([
             'featureKey' => $featureKey,
             'bucketBy' => $bucketBy,

--- a/tests/ChildTest.php
+++ b/tests/ChildTest.php
@@ -2,13 +2,12 @@
 
 namespace Featurevisor\Tests;
 
+use Featurevisor\Featurevisor;
 use PHPUnit\Framework\TestCase;
-
-use function Featurevisor\createInstance;
 
 class ChildTest extends TestCase {
     public function testCreateChildInstanceAndAllBehaviors() {
-        $f = createInstance([
+        $f = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',

--- a/tests/ConditionsTest.php
+++ b/tests/ConditionsTest.php
@@ -13,15 +13,7 @@ class ConditionsTest extends TestCase {
 
     protected function setUp(): void {
         $logger = createLogger();
-        $this->datafileReader = new DatafileReader([
-            'datafile' => [
-                'schemaVersion' => '2.0',
-                'revision' => '1',
-                'segments' => [],
-                'features' => [],
-            ],
-            'logger' => $logger,
-        ]);
+        $this->datafileReader = DatafileReader::createEmpty($logger);
     }
 
     public function testMatchAllViaStar() {

--- a/tests/ConditionsTest.php
+++ b/tests/ConditionsTest.php
@@ -3,17 +3,15 @@
 namespace Featurevisor\Tests;
 
 use DateTime;
+use Featurevisor\Logger;
 use PHPUnit\Framework\TestCase;
-
 use Featurevisor\DatafileReader;
-use function Featurevisor\createLogger;
 
 class ConditionsTest extends TestCase {
-    private $datafileReader;
+    private DatafileReader $datafileReader;
 
     protected function setUp(): void {
-        $logger = createLogger();
-        $this->datafileReader = DatafileReader::createEmpty($logger);
+        $this->datafileReader = DatafileReader::createEmpty(Logger::create());
     }
 
     public function testMatchAllViaStar() {

--- a/tests/DatafileReaderTest.php
+++ b/tests/DatafileReaderTest.php
@@ -2,10 +2,9 @@
 
 namespace Featurevisor\Tests;
 
+use Featurevisor\Logger;
 use PHPUnit\Framework\TestCase;
-
 use Featurevisor\DatafileReader;
-use function Featurevisor\createLogger;
 
 class DatafileReaderTest extends TestCase {
 
@@ -49,7 +48,7 @@ class DatafileReaderTest extends TestCase {
                 ],
             ],
         ];
-        $logger = createLogger();
+        $logger = Logger::create();
         $reader = DatafileReader::createFromOptions([
             'datafile' => $datafileJson,
             'logger' => $logger,
@@ -112,7 +111,7 @@ class DatafileReaderTest extends TestCase {
                 ],
             ],
         ];
-        $logger = createLogger();
+        $logger = Logger::create();
         $datafileReader = DatafileReader::createFromOptions([
             'datafile' => $datafileContent,
             'logger' => $logger,

--- a/tests/DatafileReaderTest.php
+++ b/tests/DatafileReaderTest.php
@@ -50,7 +50,7 @@ class DatafileReaderTest extends TestCase {
             ],
         ];
         $logger = createLogger();
-        $reader = new DatafileReader([
+        $reader = DatafileReader::createFromOptions([
             'datafile' => $datafileJson,
             'logger' => $logger,
         ]);
@@ -113,7 +113,7 @@ class DatafileReaderTest extends TestCase {
             ],
         ];
         $logger = createLogger();
-        $datafileReader = new DatafileReader([
+        $datafileReader = DatafileReader::createFromOptions([
             'datafile' => $datafileContent,
             'logger' => $logger,
         ]);

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -2,11 +2,11 @@
 
 namespace Featurevisor\Tests;
 
+use Featurevisor\Logger;
 use PHPUnit\Framework\TestCase;
 
 use Featurevisor\Events;
 use Featurevisor\DatafileReader;
-use function Featurevisor\createLogger;
 
 class EventsTest extends TestCase
 {
@@ -49,7 +49,7 @@ class EventsTest extends TestCase
 
     public function testGetParamsForDatafileSetEventEmptyToNew()
     {
-        $logger = createLogger([
+        $logger = Logger::create([
             'level' => 'error',
         ]);
 
@@ -88,7 +88,7 @@ class EventsTest extends TestCase
 
     public function testGetParamsForDatafileSetEventChangeHashAddition()
     {
-        $logger = createLogger([
+        $logger = Logger::create([
             'level' => 'error',
         ]);
 
@@ -131,7 +131,7 @@ class EventsTest extends TestCase
 
     public function testGetParamsForDatafileSetEventChangeHashRemoval()
     {
-        $logger = createLogger([
+        $logger = Logger::create([
             'level' => 'error',
         ]);
 

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -53,7 +53,7 @@ class EventsTest extends TestCase
             'level' => 'error',
         ]);
 
-        $previousDatafileReader = new DatafileReader([
+        $previousDatafileReader = DatafileReader::createFromOptions([
             'datafile' => [
                 'schemaVersion' => '1.0.0',
                 'revision' => '1',
@@ -63,7 +63,7 @@ class EventsTest extends TestCase
             'logger' => $logger,
         ]);
 
-        $newDatafileReader = new DatafileReader([
+        $newDatafileReader = DatafileReader::createFromOptions([
             'datafile' => [
                 'schemaVersion' => '1.0.0',
                 'revision' => '2',
@@ -92,7 +92,7 @@ class EventsTest extends TestCase
             'level' => 'error',
         ]);
 
-        $previousDatafileReader = new DatafileReader([
+        $previousDatafileReader = DatafileReader::createFromOptions([
             'datafile' => [
                 'schemaVersion' => '1.0.0',
                 'revision' => '1',
@@ -105,7 +105,7 @@ class EventsTest extends TestCase
             'logger' => $logger,
         ]);
 
-        $newDatafileReader = new DatafileReader([
+        $newDatafileReader = DatafileReader::createFromOptions([
             'datafile' => [
                 'schemaVersion' => '1.0.0',
                 'revision' => '2',
@@ -135,7 +135,7 @@ class EventsTest extends TestCase
             'level' => 'error',
         ]);
 
-        $previousDatafileReader = new DatafileReader([
+        $previousDatafileReader = DatafileReader::createFromOptions([
             'datafile' => [
                 'schemaVersion' => '1.0.0',
                 'revision' => '1',
@@ -148,7 +148,7 @@ class EventsTest extends TestCase
             'logger' => $logger,
         ]);
 
-        $newDatafileReader = new DatafileReader([
+        $newDatafileReader = DatafileReader::createFromOptions([
             'datafile' => [
                 'schemaVersion' => '1.0.0',
                 'revision' => '2',

--- a/tests/FeaturevisorTest.php
+++ b/tests/FeaturevisorTest.php
@@ -2,17 +2,16 @@
 
 namespace Featurevisor\Tests;
 
+use Featurevisor\Featurevisor;
 use PHPUnit\Framework\TestCase;
-
 use Psr\Log\LogLevel;
-use function Featurevisor\createInstance;
 use function Featurevisor\createLogger;
 
-class InstanceTest extends TestCase
+class FeaturevisorTest extends TestCase
 {
     public function testShouldCreateInstanceWithDatafileContent()
     {
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -28,7 +27,7 @@ class InstanceTest extends TestCase
     {
         $capturedBucketKey = '';
 
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -77,7 +76,7 @@ class InstanceTest extends TestCase
     {
         $capturedBucketKey = '';
 
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -126,7 +125,7 @@ class InstanceTest extends TestCase
     {
         $capturedBucketKey = '';
 
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -183,7 +182,7 @@ class InstanceTest extends TestCase
         $interceptedFeatureKey = '';
         $interceptedVariableKey = '';
 
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -236,7 +235,7 @@ class InstanceTest extends TestCase
         $interceptedFeatureKey = '';
         $interceptedVariableKey = '';
 
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -310,7 +309,7 @@ class InstanceTest extends TestCase
             'segments' => [],
         ];
 
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'sticky' => [
                 'test' => [
                     'enabled' => true,
@@ -346,7 +345,7 @@ class InstanceTest extends TestCase
 
     public function testShouldHonourSimpleRequiredFeatures()
     {
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -385,7 +384,7 @@ class InstanceTest extends TestCase
         self::assertFalse($sdk->isEnabled('myKey'));
 
         // enabling required should enable the feature too
-        $sdk2 = createInstance([
+        $sdk2 = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -425,7 +424,7 @@ class InstanceTest extends TestCase
     public function testShouldHonourRequiredFeaturesWithVariation()
     {
         // should be disabled because required has different variation
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -472,7 +471,7 @@ class InstanceTest extends TestCase
         self::assertFalse($sdk->isEnabled('myKey'));
 
         // child should be enabled because required has desired variation
-        $sdk2 = createInstance([
+        $sdk2 = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -522,7 +521,7 @@ class InstanceTest extends TestCase
     {
         $deprecatedCount = 0;
 
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -586,7 +585,7 @@ class InstanceTest extends TestCase
 
     public function testShouldCheckIfEnabledForOverriddenFlagsFromRules()
     {
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -634,7 +633,7 @@ class InstanceTest extends TestCase
     {
         $bucketValue = 10000;
 
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'hooks' => [
                 [
                     'name' => 'unit-test',
@@ -670,7 +669,7 @@ class InstanceTest extends TestCase
 
     public function testShouldGetVariation()
     {
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -750,7 +749,7 @@ class InstanceTest extends TestCase
 
     public function testShouldGetVariable()
     {
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -1037,7 +1036,7 @@ class InstanceTest extends TestCase
 
     public function testShouldGetVariablesWithoutAnyVariations()
     {
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',
@@ -1099,7 +1098,7 @@ class InstanceTest extends TestCase
 
     public function testShouldCheckIfEnabledForIndividuallyNamedSegments()
     {
-        $sdk = createInstance([
+        $sdk = Featurevisor::createInstance([
             'datafile' => [
                 'schemaVersion' => '2',
                 'revision' => '1.0',

--- a/tests/FeaturevisorTest.php
+++ b/tests/FeaturevisorTest.php
@@ -3,9 +3,9 @@
 namespace Featurevisor\Tests;
 
 use Featurevisor\Featurevisor;
+use Featurevisor\Logger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
-use function Featurevisor\createLogger;
 
 class FeaturevisorTest extends TestCase
 {
@@ -562,7 +562,7 @@ class FeaturevisorTest extends TestCase
                 ],
                 'segments' => [],
             ],
-            'logger' => createLogger([
+            'logger' => Logger::create([
                 'handler' => function($level, $message) use (&$deprecatedCount) {
                     if ($level === LogLevel::WARNING && strpos($message, 'is deprecated') !== false) {
                         $deprecatedCount += 1;

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\TestCase;
 
 use Featurevisor\Logger;
 use Psr\Log\LogLevel;
-use function Featurevisor\createLogger;
 
 class LoggerTest extends TestCase
 {
@@ -29,13 +28,13 @@ class LoggerTest extends TestCase
 
     public function testCreateLoggerWithDefaultOptions(): void
     {
-        $logger = createLogger();
+        $logger = Logger::create();
         self::assertInstanceOf(Logger::class, $logger);
     }
 
     public function testCreateLoggerWithCustomLevel(): void
     {
-        $logger = createLogger(['level' => 'debug']);
+        $logger = Logger::create(['level' => 'debug']);
         self::assertInstanceOf(Logger::class, $logger);
     }
 
@@ -49,7 +48,7 @@ class LoggerTest extends TestCase
             self::assertSame([], $details);
         };
 
-        $logger = createLogger(['handler' => $customHandler]);
+        $logger = Logger::create(['handler' => $customHandler]);
         $logger->info('test message');
 
         self::assertTrue($customHandlerCalled);
@@ -57,7 +56,7 @@ class LoggerTest extends TestCase
 
     public function testLoggerConstructorUsesDefaultLogLevelWhenNoneProvided(): void
     {
-        $logger = new Logger([]);
+        $logger = Logger::create();
 
         // Capture output to verify debug is not logged with default level (info)
         $logger->debug('debug message');
@@ -94,7 +93,7 @@ class LoggerTest extends TestCase
             self::assertSame([], $details);
         };
 
-        $logger = new Logger(['handler' => $customHandler]);
+        $logger = Logger::create(['handler' => $customHandler]);
         $logger->info('test message');
 
         self::assertTrue($customHandlerCalled);
@@ -205,7 +204,7 @@ class LoggerTest extends TestCase
             self::assertEquals(['test' => true], $details);
         };
 
-        $logger = new Logger(['handler' => $customHandler, 'level' => 'debug']);
+        $logger = Logger::create(['handler' => $customHandler, 'level' => 'debug']);
         $details = ['test' => true];
 
         $logger->log('info', 'test message', $details);
@@ -220,7 +219,7 @@ class LoggerTest extends TestCase
             $customHandlerCalled = true;
         };
 
-        $logger = new Logger(['handler' => $customHandler, 'level' => LogLevel::WARNING]);
+        $logger = Logger::create(['handler' => $customHandler, 'level' => LogLevel::WARNING]);
 
         $logger->log('debug', 'debug message');
         self::assertFalse($customHandlerCalled);
@@ -228,9 +227,9 @@ class LoggerTest extends TestCase
 
     private function getLogger(string $level = Logger::DEFAULT_LEVEL): Logger
     {
-        return new Logger(['level' => $level, 'handler' => function ($level, $message, array $context) {
+        return Logger::create(['level' => $level, 'handler' => function ($level, $message, array $context) {
             $context = $context !== [] ? ' ' . json_encode($context, JSON_THROW_ON_ERROR) : '';
-            $this->logBuffer .= $message.$context.PHP_EOL;
+            $this->logBuffer .= $message . $context . PHP_EOL;
         }]);
     }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -2,7 +2,6 @@
 
 namespace Featurevisor\Tests;
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use Featurevisor\Logger;


### PR DESCRIPTION
## Summary
This PR replaces global helper functions with static constructors on their respective classes, providing better developer experience through IDE autocompletion, improved code organization, and more efficient autoloading. It will give similar experience to Java SDK. 

## Changes

### 1. Replace `createInstance` function with static constructor
- Moved the `createInstance()` global function to a static method on the `Featurevisor` class
- All instantiation is now done through `Featurevisor::createInstance()` 
- Improves IDE completion and static analysis

### 2. Replace `createLogger` function with static constructor
- Moved the `createLogger()` global function to a static method on the `Logger` class
- All logger instantiation is now done through `Logger::create()`
- Removed unnecessary `functions.php` file as all helpers have been moved to their classes

## Migration Impact

This is a backward-incompatible change that requires users to update their code to use the static constructors:

- Replace `use function Featurevisor\createInstance;` with `use Featurevisor\Featurevisor;`
- Replace `createInstance([...])` with `Featurevisor::createInstance([...])`
- Replace `use function Featurevisor\createLogger;` with `use Featurevisor\Logger;`
- Replace `createLogger([...])` with `Logger::create([...])`