### PR TITLE
chore: Static analysis tool rule level upgrade

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,27 @@ parameters:
 	paths:
 		- src
 		- tests
+	ignoreErrors:
+		-
+			message: '#^Call to function is_array\(\) with mixed will always evaluate to false\.$#'
+			identifier: function.impossibleType
+			count: 1
+			path: src/Bucketer.php
+
+		-
+			message: '#^Offset ''or'' on \*NEVER\* in isset\(\) always exists and is not nullable\.$#'
+			identifier: isset.offset
+			count: 1
+			path: src/Bucketer.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between mixed and null will always evaluate to true\.$#'
+			identifier: notIdentical.alwaysTrue
+			count: 1
+			path: src/EvaluateSticky.php
+
+		-
+			message: '#^Call to function method_exists\(\) with Featurevisor\\Featurevisor and ''getVariation'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 1
+			path: tests/FeaturevisorTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
-	level: 3
+	level: 4
+	treatPhpDocTypesAsCertain: false
 	paths:
 		- src
 		- tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-	level: 4
+	level: 5
 	treatPhpDocTypesAsCertain: false
 	paths:
 		- src

--- a/src/CompareVersions.php
+++ b/src/CompareVersions.php
@@ -32,10 +32,6 @@ class CompareVersions
 
     private static function validateAndParse(string $version): array
     {
-        if (!is_string($version)) {
-            throw new \TypeError('Invalid argument expected string');
-        }
-
         if (!preg_match(self::$semver, $version, $match)) {
             throw new \Exception("Invalid argument not valid semver ('$version' received)");
         }

--- a/src/Featurevisor.php
+++ b/src/Featurevisor.php
@@ -560,20 +560,18 @@ class Featurevisor
                 'flagEvaluation' => $flagEvaluation,
             ]);
             // variation
-            if (method_exists($this->datafileReader, 'hasVariations') && $this->datafileReader->hasVariations($featureKey)) {
+            if ($this->datafileReader->hasVariations($featureKey)) {
                 $variation = $this->getVariation($featureKey, $context, $opts);
                 if ($variation !== null) {
                     $evaluatedFeature['variation'] = $variation;
                 }
             }
             // variables
-            if (method_exists($this->datafileReader, 'getVariableKeys')) {
-                $variableKeys = $this->datafileReader->getVariableKeys($featureKey);
-                if (!empty($variableKeys)) {
-                    $evaluatedFeature['variables'] = [];
-                    foreach ($variableKeys as $variableKey) {
-                        $evaluatedFeature['variables'][$variableKey] = $this->getVariable($featureKey, $variableKey, $context, $opts);
-                    }
+            $variableKeys = $this->datafileReader->getVariableKeys($featureKey);
+            if (!empty($variableKeys)) {
+                $evaluatedFeature['variables'] = [];
+                foreach ($variableKeys as $variableKey) {
+                    $evaluatedFeature['variables'][$variableKey] = $this->getVariable($featureKey, $variableKey, $context, $opts);
                 }
             }
             $evaluations[$featureKey] = $evaluatedFeature;

--- a/src/Featurevisor.php
+++ b/src/Featurevisor.php
@@ -23,10 +23,10 @@ class Featurevisor
      *     sticky?: array<string, mixed>,
      *     hooks?: array<array{
      *         name: string,
-     *         before: Closure,
-     *         after: Closure,
-     *         bucketKey: Closure,
-     *         bucketValue: Closure
+     *         before?: Closure,
+     *         after?: Closure,
+     *         bucketKey?: Closure,
+     *         bucketValue?: Closure
      *    }>
      * } $options
      * @return self

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -72,7 +72,7 @@ class Logger implements LoggerInterface
 
     private static function defaultLogHandler($level, $message, ?array $details = null): void
     {
-        if (STDOUT === false) {
+        if (STDOUT == false) {
             return;
         }
 

--- a/tests/ChildTest.php
+++ b/tests/ChildTest.php
@@ -147,14 +147,12 @@ class ChildTest extends TestCase {
             'context' => [ 'appVersion' => '1.0.0' ],
         ]);
 
-        self::assertNotNull($f);
         self::assertEquals(['appVersion' => '1.0.0'], $f->getContext());
 
         $childF = $f->spawn([
             'userId' => '123',
             'country' => 'nl',
         ]);
-        self::assertNotNull($childF);
         self::assertEquals([
             'appVersion' => '1.0.0',
             'userId' => '123',


### PR DESCRIPTION
Fixed issues related to level 5 of PHPStan rules.
Ignored 4 issues related to not declared array type contents. 